### PR TITLE
[GRDM-38505] 新規ファイルのinvalidate処理の修正

### DIFF
--- a/rdmfs/node.py
+++ b/rdmfs/node.py
@@ -182,4 +182,4 @@ class NewFile(BaseFileContext):
         await self.storage.create_file(self.path, fp)
 
     async def _invalidate(self):
-        self.context.inodes.clear_inode_cache(self.storage, self.path)
+        self.context.inodes.clear_inode_cache(self.storage, '/' + self.path)


### PR DESCRIPTION
新規ファイルを作成した直後にファイルサイズが0となってしまう問題の修正。