### PR TITLE
pyfuse3バージョン3.4.2以降への対応

### DIFF
--- a/rdmfs/__main__.py
+++ b/rdmfs/__main__.py
@@ -6,12 +6,12 @@ import grp
 import pwd
 import re
 import pyfuse3
-import pyfuse3_asyncio
+import pyfuse3.asyncio
 from rdmfs import fs, whitelist
 from osfclient import cli
 
 
-pyfuse3_asyncio.enable()
+pyfuse3.asyncio.enable()
 
 def init_logging(debug=False):
     formatter = logging.Formatter('%(asctime)s.%(msecs)03d %(levelname)s %(threadName)s: '


### PR DESCRIPTION
pyfuse3は`requirements.txt`の中でバージョンの指定がなく、2026年2月現在ではpyfuse3はバージョン3.4.2がインストールされますが、このバージョンから`pyfuse3_asyncio`が`pyfuse3.asyncio`に完全に置き換えられ、`pyfuse3_asyncio`は削除されました。本PRは全ての`pyfuse3_asyncio`の出現を`pyfuse3.asyncio`に置き換えることにより、この変更に追従するためのものです。